### PR TITLE
Standardize module-chunker build process

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -2,61 +2,27 @@ name: Build and Publish
 
 on:
   push:
-    branches:
-      - main
+    branches: [main]
   pull_request:
-    branches:
-      - main
+    branches: [main]
 
 jobs:
   build:
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Full history for versioning
 
-      - uses: actions/setup-java@v4
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
         with:
           java-version: '21'
           distribution: 'temurin'
 
-      - run: chmod +x gradlew
-
-      - name: Build and test
-        env:
-          GITHUB_ACTOR: ${{ github.actor }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: ./gradlew clean build test --no-daemon
-
-      - name: Upload test results
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: test-results
-          path: build/test-results/
-
-      - name: Publish to GitHub Packages
-        if: github.ref == 'refs/heads/main'
-        env:
-          GITHUB_ACTOR: ${{ github.actor }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: ./gradlew publishAllPublicationsToGitHubPackagesRepository --no-daemon
-
-  publish-central:
-    runs-on: ubuntu-latest
-    needs: build
-    if: github.ref == 'refs/heads/main'
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: actions/setup-java@v4
-        with:
-          java-version: '21'
-          distribution: 'temurin'
-
-      - uses: actions/cache@v3
+      - name: Cache Gradle packages
+        uses: actions/cache@v3
         with:
           path: |
             ~/.gradle/caches
@@ -65,24 +31,23 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gradle-
 
-      - run: chmod +x gradlew
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
 
-      - name: Configure GPG (if available)
-        if: env.GPG_SIGNING_KEY != ''
+      - name: Build and test with Gradle
         env:
-          GPG_SIGNING_KEY: ${{ secrets.GPG_SIGNING_KEY }}
-        run: |
-          echo "$GPG_SIGNING_KEY" | gpg --batch --import
+          GITHUB_ACTOR: ${{ github.actor }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: ./gradlew clean build test --no-daemon --refresh-dependencies
 
-      - name: Publish snapshots to Maven Central
-        env:
-          MAVEN_CENTRAL_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
-          MAVEN_CENTRAL_PASSWORD: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
-          GPG_SIGNING_KEY: ${{ secrets.GPG_SIGNING_KEY }}
-          GPG_SIGNING_PASSPHRASE: ${{ secrets.GPG_SIGNING_PASSPHRASE }}
-        run: ./gradlew publishAllPublicationsToCentralPortalSnapshots --no-daemon
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results
+          path: build/test-results/
 
-  docker:
+  publish-snapshots:
     runs-on: ubuntu-latest
     needs: build
     if: github.ref == 'refs/heads/main'
@@ -90,32 +55,101 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
-      - uses: actions/setup-java@v4
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
         with:
           java-version: '21'
           distribution: 'temurin'
 
-      - run: chmod +x gradlew
+      - name: Cache Gradle packages
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
 
-      - uses: docker/setup-buildx-action@v3
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
 
-      - uses: docker/login-action@v3
+      - name: Configure GPG (if available)
+        env:
+          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+        if: env.GPG_PRIVATE_KEY != ''
+        run: |
+          echo "$GPG_PRIVATE_KEY" | gpg --batch --import
+
+      - name: Publish snapshots to Central
+        env:
+          MAVEN_CENTRAL_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+          MAVEN_CENTRAL_PASSWORD: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
+          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+        run: ./gradlew publishAllPublicationsToCentralPortalSnapshots --no-daemon --stacktrace
+
+      - name: Publish snapshots to GitHub Packages
+        env:
+          GITHUB_ACTOR: ${{ github.actor }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: ./gradlew publish -PskipCentral=true --no-daemon --stacktrace
+
+  docker-snapshot:
+    runs-on: ubuntu-latest
+    needs:
+      - build
+      - publish-snapshots
+    if: github.ref == 'refs/heads/main'
+    permissions:
+      contents: write
+      packages: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+
+      - name: Cache Gradle packages
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and push Docker image
-        env:
-          GITHUB_ACTOR: ${{ github.actor }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push snapshot Docker image
         run: |
-          ./gradlew build -x test \
+          ./gradlew clean build -x test \
             -Dquarkus.container-image.build=true \
             -Dquarkus.container-image.push=true \
             -Dquarkus.container-image.registry=ghcr.io \
             -Dquarkus.container-image.group=ai-pipestream \
+            -Dquarkus.container-image.name=module-chunker \
+            -Dquarkus.container-image.tag=${{ github.ref_name }}-${{ github.sha }} \
             -Dquarkus.container-image.additional-tags=${{ github.sha }} \
             --no-daemon

--- a/.github/workflows/dockerhub-publish.yml
+++ b/.github/workflows/dockerhub-publish.yml
@@ -1,0 +1,50 @@
+name: Docker Hub Publish
+
+on:
+  repository_dispatch:
+    types: [dockerhub-publish]
+
+jobs:
+  push-to-dockerhub:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read
+    steps:
+      - name: Validate payload
+        run: |
+          echo "Payload: ${{ toJson(github.event.client_payload) }}"
+          if [ -z "${{ github.event.client_payload.base_image }}" ] || [ -z "${{ github.event.client_payload.dockerhub_repo }}" ] || [ -z "${{ github.event.client_payload.tags }}" ]; then
+            echo "Missing required client_payload fields: base_image, dockerhub_repo, tags" >&2
+            exit 1
+          fi
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USER }}
+          password: ${{ secrets.DOCKER_TOKEN }}
+
+      - name: Pull from GHCR, retag, and push to Docker Hub
+        env:
+          BASE_IMAGE: ${{ github.event.client_payload.base_image }}
+          DOCKERHUB_REPO: ${{ github.event.client_payload.dockerhub_repo }}
+          TAGS: ${{ github.event.client_payload.tags }}
+        run: |
+          set -euo pipefail
+          echo "Processing tags: $TAGS"
+          for TAG in $TAGS; do
+            echo "Pulling $BASE_IMAGE:$TAG"
+            docker pull "$BASE_IMAGE:$TAG"
+            echo "Tagging to $DOCKERHUB_REPO:$TAG"
+            docker tag "$BASE_IMAGE:$TAG" "$DOCKERHUB_REPO:$TAG"
+            echo "Pushing $DOCKERHUB_REPO:$TAG"
+            docker push "$DOCKERHUB_REPO:$TAG"
+          done

--- a/.github/workflows/release-and-publish.yml
+++ b/.github/workflows/release-and-publish.yml
@@ -1,0 +1,270 @@
+name: Release and Publish
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_type:
+        description: 'Release type (patch, minor, major, or manual)'
+        required: true
+        default: 'patch'
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+          - manual
+      custom_version:
+        description: 'Custom version (only for manual release type, e.g., 1.0.0)'
+        required: false
+        type: string
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+
+      - name: Cache Gradle packages
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Build and test with Gradle
+        env:
+          GITHUB_ACTOR: ${{ github.actor }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: ./gradlew clean build test --no-daemon --refresh-dependencies
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results
+          path: build/test-results/
+
+  release:
+    runs-on: ubuntu-latest
+    needs: build
+    permissions:
+      contents: write
+      packages: write
+    outputs:
+      version: ${{ steps.get_version.outputs.version }}
+      tag: ${{ steps.get_version.outputs.tag }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+
+      - name: Cache Gradle packages
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Configure Git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Determine version
+        id: get_version
+        run: |
+          if [ "${{ inputs.release_type }}" == "manual" ]; then
+            VERSION="${{ inputs.custom_version }}"
+          else
+            # Get current version from axion-release
+            CURRENT=$(./gradlew currentVersion -q --no-daemon | tail -1)
+            echo "Raw version output: $CURRENT"
+
+            # Strip "Project version: " prefix if present
+            CURRENT=${CURRENT#Project version: }
+            echo "Parsed version: $CURRENT"
+
+            # Remove -SNAPSHOT suffix if present
+            CURRENT=${CURRENT%-SNAPSHOT}
+
+            # Parse version components
+            IFS='.' read -r MAJOR MINOR PATCH <<< "$CURRENT"
+
+            case "${{ inputs.release_type }}" in
+              major)
+                VERSION="$((MAJOR + 1)).0.0"
+                ;;
+              minor)
+                VERSION="${MAJOR}.$((MINOR + 1)).0"
+                ;;
+              patch)
+                VERSION="${MAJOR}.${MINOR}.$((PATCH + 1))"
+                ;;
+            esac
+          fi
+
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "tag=v$VERSION" >> $GITHUB_OUTPUT
+          echo "Release version: $VERSION"
+
+      - name: Create release tag
+        run: |
+          git tag -a "${{ steps.get_version.outputs.tag }}" -m "Release ${{ steps.get_version.outputs.version }}"
+          git push origin "${{ steps.get_version.outputs.tag }}"
+
+      - name: Configure GPG (if available)
+        env:
+          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+        if: env.GPG_PRIVATE_KEY != ''
+        run: |
+          echo "$GPG_PRIVATE_KEY" | gpg --batch --import
+
+      - name: Publish to Maven Central
+        env:
+          MAVEN_CENTRAL_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+          MAVEN_CENTRAL_PASSWORD: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
+          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+        run: ./gradlew publishAllPublicationsToCentralPortal --no-daemon --stacktrace
+
+      - name: Publish to GitHub Packages
+        env:
+          GITHUB_ACTOR: ${{ github.actor }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: ./gradlew publish -PskipCentral=true --no-daemon --stacktrace
+
+      - name: Build release artifacts
+        run: |
+          ./gradlew clean build -x test --no-daemon
+          mkdir -p release-assets
+          cp build/libs/*.jar release-assets/
+          cp DOCKER_RUN.md release-assets/ 2>/dev/null || true
+          cp README.md release-assets/
+          cd release-assets && zip -r ../module-chunker-${{ steps.get_version.outputs.version }}.zip . && cd ..
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ steps.get_version.outputs.tag }}
+          name: Release ${{ steps.get_version.outputs.version }}
+          body: |
+            ## Module Chunker ${{ steps.get_version.outputs.version }}
+
+            ### Maven Coordinates
+            ```xml
+            <dependency>
+              <groupId>ai.pipestream.module</groupId>
+              <artifactId>module-chunker</artifactId>
+              <version>${{ steps.get_version.outputs.version }}</version>
+            </dependency>
+            ```
+
+            ### Docker Images
+            - GHCR: `ghcr.io/ai-pipestream/module-chunker:${{ steps.get_version.outputs.version }}`
+            - Docker Hub: `pipestreamai/module-chunker:${{ steps.get_version.outputs.version }}`
+
+            ### Changes
+            See commit history for detailed changes.
+          files: |
+            module-chunker-${{ steps.get_version.outputs.version }}.zip
+          draft: false
+          prerelease: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  docker-production:
+    runs-on: ubuntu-latest
+    needs: release
+    permissions:
+      contents: write
+      packages: write
+    steps:
+      - name: Checkout release tag
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.release.outputs.tag }}
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+
+      - name: Cache Gradle packages
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        run: |
+          ./gradlew clean build -x test \
+            -Dquarkus.container-image.build=true \
+            -Dquarkus.container-image.push=true \
+            -Dquarkus.container-image.registry=ghcr.io \
+            -Dquarkus.container-image.group=ai-pipestream \
+            -Dquarkus.container-image.name=module-chunker \
+            -Dquarkus.container-image.tag=${{ needs.release.outputs.version }} \
+            -Dquarkus.container-image.additional-tags=latest \
+            --no-daemon
+
+      - name: Trigger Docker Hub publish
+        if: success()
+        continue-on-error: true
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.DISPATCH_TOKEN }}
+          repository: ${{ github.repository }}
+          event-type: dockerhub-publish
+          client-payload: |
+            {
+              "base_image": "ghcr.io/ai-pipestream/module-chunker",
+              "dockerhub_repo": "pipestreamai/module-chunker",
+              "tags": "${{ needs.release.outputs.version }} latest"
+            }

--- a/build.gradle
+++ b/build.gradle
@@ -1,12 +1,27 @@
+import org.apache.tools.ant.filters.ReplaceTokens
+import org.gradle.plugins.signing.Sign
+
 plugins {
+    id 'pl.allegro.tech.build.axion-release' version '1.21.0'
     alias(libs.plugins.java)
     alias(libs.plugins.quarkus)
     alias(libs.plugins.maven.publish)
     id 'signing'
-    id 'com.gradleup.nmcp' version '1.2.0'
+    id 'com.gradleup.nmcp' version '1.2.1'
 }
 
-def pipelineBomVersion = findProperty('pipelineBomVersion') ?: '0.1.2-SNAPSHOT'
+scmVersion {
+    tag {
+        prefix = 'v'
+    }
+    checks {
+        uncommittedChanges = false
+        aheadOfRemote = false
+        snapshotDependencies = false
+    }
+}
+
+def pipelineBomVersion = findProperty('pipelineBomVersion') ?: '0.2.2'
 
 dependencies {
     implementation 'io.quarkus:quarkus-container-image-docker'
@@ -17,13 +32,13 @@ dependencies {
     implementation 'io.quarkus:quarkus-arc'
     implementation 'io.quarkus:quarkus-smallrye-health'
     implementation 'io.quarkus:quarkus-smallrye-stork'
-    
+
     // REST API dependencies
     implementation 'io.quarkus:quarkus-rest'
     implementation 'io.quarkus:quarkus-rest-jackson'
     implementation 'io.quarkus:quarkus-smallrye-openapi'
     implementation 'io.quarkus:quarkus-hibernate-validator'
-    
+
     // Service Discovery dependencies for Consul
     implementation 'io.smallrye.stork:stork-service-discovery-consul'
     implementation 'io.smallrye.reactive:smallrye-mutiny-vertx-consul-client'
@@ -48,11 +63,13 @@ dependencies {
 }
 
 group = "ai.pipestream.module"
-version = "${pipelineBomVersion}"
+version = "${scmVersion.version}"
 
 java {
     sourceCompatibility = JavaVersion.VERSION_21
     targetCompatibility = JavaVersion.VERSION_21
+    withJavadocJar()
+    withSourcesJar()
 }
 
 test {
@@ -67,25 +84,56 @@ compileTestJava {
     options.encoding = 'UTF-8'
 }
 
+// Configure Javadoc task
+tasks.withType(Javadoc).configureEach { task ->
+    def opts = task.options
+    opts.encoding = 'UTF-8'
+    opts.charSet = 'UTF-8'
+    opts.locale = 'en'
+    // Suppress missing Javadoc warnings for now
+    opts.addStringOption('Xdoclint:-missing', '-quiet')
+    // Exclude internal packages
+    task.exclude('**/internal/**', '**/impl/**', '**/test/**')
+}
+
+// Enable resource filtering to replace @version@ in application.properties
+// Use @ delimiters to avoid conflicts with ${} runtime property placeholders
+processResources {
+    filesMatching('**/*.properties') {
+        filter(ReplaceTokens, tokens: [
+            version: project.version.toString()
+        ])
+    }
+}
+
+processTestResources {
+    filesMatching('**/*.properties') {
+        filter(ReplaceTokens, tokens: [
+            version: project.version.toString()
+        ])
+    }
+}
+
 // Publishing configuration
 publishing {
     publications {
-        //noinspection GroovyAssignabilityCheck
-        maven(MavenPublication) { publication ->
+        // Use a named publication to match signing configuration below
+        create('maven', MavenPublication) {
             from components.java
             //noinspection GroovyAssignabilityCheck
             artifact(file("${buildDir}/quarkus-app/quarkus-run.jar")) { artifact ->
                 artifact.classifier = 'runner'
                 artifact.builtBy tasks.named('quarkusBuild')
             }
-            pom { pom ->
+            pom {
                 name.set('Module Chunker')
                 description.set('Document chunking module for the Pipeline platform')
                 url.set('https://github.com/ai-pipestream/module-chunker')
+
                 licenses {
                     license {
                         name.set('MIT License')
-                        url.set('https://opensource.org/licenses/MIT')
+                        url.set('https://opensource.org/license/mit')
                     }
                 }
 
@@ -101,6 +149,46 @@ publishing {
                     developerConnection.set('scm:git:ssh://github.com/ai-pipestream/module-chunker.git')
                     url.set('https://github.com/ai-pipestream/module-chunker')
                 }
+
+                // Ensure BOM/platform dependency is included in dependencyManagement
+                // This ensures Maven Central can resolve dependency versions from the BOM
+                withXml {
+                    def projectNode = asNode()
+                    def dependencyManagementNodes = projectNode.get('dependencyManagement')
+                    def dmNode
+                    def depsNode
+
+                    if (dependencyManagementNodes.isEmpty()) {
+                        // Create dependencyManagement and dependencies nodes
+                        dmNode = projectNode.appendNode('dependencyManagement')
+                        depsNode = dmNode.appendNode('dependencies')
+                    } else {
+                        // Get the first dependencyManagement node
+                        dmNode = dependencyManagementNodes[0]
+                        // Check if it has a dependencies child
+                        def dependenciesNodes = dmNode.get('dependencies')
+                        if (dependenciesNodes.isEmpty()) {
+                            depsNode = dmNode.appendNode('dependencies')
+                        } else {
+                            depsNode = dependenciesNodes[0]
+                        }
+                    }
+
+                    // Check if pipeline-bom already exists
+                    def existingBom = depsNode.children().find { dep ->
+                        dep.groupId?.text() == 'ai.pipestream' &&
+                        dep.artifactId?.text() == 'pipeline-bom'
+                    }
+
+                    if (!existingBom) {
+                        def bomDependency = depsNode.appendNode('dependency')
+                        bomDependency.appendNode('groupId', 'ai.pipestream')
+                        bomDependency.appendNode('artifactId', 'pipeline-bom')
+                        bomDependency.appendNode('version', pipelineBomVersion)
+                        bomDependency.appendNode('type', 'pom')
+                        bomDependency.appendNode('scope', 'import')
+                    }
+                }
             }
         }
     }
@@ -108,17 +196,18 @@ publishing {
     repositories {
         // Publish to Maven Local for development
         mavenLocal()
-        def githubToken = providers.environmentVariable("GITHUB_TOKEN")
-        if (githubToken.isPresent()) {
+
+        // Conditionally add GitHub Packages repository when credentials are available
+        def ghRepo = System.getenv('GITHUB_REPOSITORY') ?: 'ai-pipestream/module-chunker'
+        def ghActor = System.getenv('GITHUB_ACTOR') ?: (project.findProperty('gpr.user') ?: System.getenv('GPR_USER'))
+        def ghToken = System.getenv('GITHUB_TOKEN') ?: (project.findProperty('gpr.key') ?: System.getenv('GPR_TOKEN'))
+        if (ghActor && ghToken) {
             maven {
-                name = "GitHubPackages"
-                url = uri("https://maven.pkg.github.com/ai-pipestream/module-chunker")
+                name = 'GitHubPackages'
+                url = uri("https://maven.pkg.github.com/${ghRepo}")
                 credentials {
-                    username = providers.environmentVariable("GITHUB_ACTOR").getOrElse("github-actions")
-                    password = githubToken.get()
-                }
-                mavenContent {
-                    releasesOnly()
+                    username = ghActor
+                    password = ghToken
                 }
             }
         }
@@ -126,13 +215,22 @@ publishing {
 }
 
 signing {
-    def signingKey = System.getenv("GPG_SIGNING_KEY")
-    def signingPassword = System.getenv("GPG_SIGNING_PASSPHRASE")
+    // Read org-level GPG secrets directly, so runnable apps don't need extra env mapping
+    def signingKey = System.getenv("GPG_PRIVATE_KEY")
+    def signingPassword = System.getenv("GPG_PASSPHRASE")
 
     if (signingKey && signingPassword) {
         useInMemoryPgpKeys(signingKey, signingPassword)
         sign publishing.publications.maven
     }
+}
+
+// Ensure all signing tasks run before nmcp bundles and publishes artifacts
+afterEvaluate {
+    tasks.matching { it.name.startsWith("nmcpZipAllPublications") || it.name.startsWith("nmcpPublishAllPublicationsToCentralPortal") }
+        .configureEach { nmcpTask ->
+            nmcpTask.dependsOn(tasks.withType(Sign))
+        }
 }
 
 nmcp {


### PR DESCRIPTION
- Add axion-release plugin for automatic semantic versioning
- Create separate workflows for CI and releases
- Add build-and-publish.yml for snapshot publishing
- Add release-and-publish.yml for production releases
- Add dockerhub-publish.yml for Docker Hub mirroring
- Configure GPG signing for Maven Central
- Add javadoc and sources jars generation
- Update NMCP plugin to v1.2.1
- Add BOM dependency management in POM
- Configure resource filtering for version tokens