### PR TITLE
chore(chunker): PR-K3 — remove loose-map duplicates from ChunkerGrpcImpl

### DIFF
--- a/src/main/java/ai/pipestream/module/chunker/ChunkerGrpcImpl.java
+++ b/src/main/java/ai/pipestream/module/chunker/ChunkerGrpcImpl.java
@@ -552,29 +552,14 @@ public class ChunkerGrpcImpl implements PipeStepProcessorService {
                         && !placeholderToUrlMap.isEmpty()
                         && placeholderToUrlMap.keySet().stream().anyMatch(ph -> c.text().contains(ph));
 
-                // PR-I: compute the NLP slice ONCE per chunk and reuse it for
-                // both extractAllMetadata and extractChunkAnalytics. If
-                // nlpForSlicing is null (URL substitution invalidated offsets
-                // for this whole pass) sliceForChunk returns null and both
-                // metadata methods fall back to running OpenNLP per chunk.
+                // PR-I: compute the NLP slice ONCE per chunk so extractChunkAnalytics
+                // doesn't re-run OpenNLP on the chunk text. If nlpForSlicing is
+                // null (URL substitution invalidated offsets for this whole
+                // pass) sliceForChunk returns null and the metadata methods
+                // fall back to running OpenNLP per chunk.
                 ChunkMetadataExtractor.ChunkNlpSlice nlpSlice =
                         metadataExtractor.sliceForChunk(nlpForSlicing,
                                 c.originalIndexStart(), c.originalIndexEnd());
-
-                Map<String, Value> extractedMetadata = metadataExtractor.extractAllMetadata(
-                        sanitizedText, chunkNumber, chunkRecords.size(), containsUrlPlaceholder, nlpSlice);
-
-                // §9 dedup groundwork: SHA-256 content_hash of the sanitised
-                // chunk text, stamped into the chunk metadata map. Identical
-                // sanitised text → identical hash, so reprocessing can skip
-                // already-computed chunks, downstream embedders can use the
-                // hash as a cache key, and a future OpenVINO chunker backend
-                // can be byte-verified against this implementation via hash
-                // equality on the same input. Same scheme the streaming impl
-                // uses at ChunkerStreamingGrpcImpl.java:139-141.
-                String contentHash = ChunkerSupport.sha256Hex(sanitizedText);
-                extractedMetadata.put("content_hash",
-                        Value.newBuilder().setStringValue(contentHash).build());
 
                 // §4.1: chunk_analytics is ALWAYS populated. The streaming impl at
                 // ChunkerStreamingGrpcImpl already does this; the non-streaming
@@ -590,11 +575,10 @@ public class ChunkerGrpcImpl implements PipeStepProcessorService {
                         nlpSlice, nlpForSlicing,
                         c.originalIndexStart(), c.originalIndexEnd());
 
-                // PR-K2: promote content_hash to the typed ChunkAnalytics field
-                // (pipestream-protos PR #38 added the field). Keeps the loose-
-                // map "content_hash" entry above intact for backward compat —
-                // the duplication will be removed in a follow-up PR after a
-                // consumer audit confirms no readers depend on the loose key.
+                // PR-K2 promoted content_hash to the typed ChunkAnalytics field.
+                // PR-K3 removed the duplicate write to the loose metadata map —
+                // chunk_analytics.content_hash is now the canonical home.
+                String contentHash = ChunkerSupport.sha256Hex(sanitizedText);
                 chunkAnalytics = chunkAnalytics.toBuilder()
                         .setContentHash(contentHash)
                         .build();
@@ -608,12 +592,17 @@ public class ChunkerGrpcImpl implements PipeStepProcessorService {
                         // vector intentionally NOT set — stage-1 placeholder (§4.1)
                         .build();
 
+                // PR-K3: SemanticChunk.metadata is no longer populated by the
+                // chunker. All 17 fields it used to hold (word_count,
+                // character_count, is_first_chunk, etc.) PLUS content_hash
+                // now live exclusively on the typed ChunkAnalytics proto.
+                // The loose map remains as an extension point for future
+                // caller-injected metadata that doesn't fit the typed schema.
                 SemanticChunk semanticChunk = SemanticChunk.newBuilder()
                         .setChunkId(chunkId)
                         .setChunkNumber(chunkNumber)
                         .setEmbeddingInfo(embedding)
                         .setChunkAnalytics(chunkAnalytics)
-                        .putAllMetadata(extractedMetadata)
                         .build();
 
                 chunks.add(semanticChunk);
@@ -689,29 +678,10 @@ public class ChunkerGrpcImpl implements PipeStepProcessorService {
             // nlpResult is ALWAYS safe to slice here (no URL substitution
             // happens on this code path — sentences come straight from the
             // NLP run on the unmodified source text). Compute the slice
-            // ONCE per sentence and pass it to both metadata methods so we
-            // never re-run OpenNLP on individual sentence chunks.
+            // ONCE per sentence so extractChunkAnalytics doesn't re-run
+            // OpenNLP on individual sentence chunks.
             ChunkMetadataExtractor.ChunkNlpSlice nlpSlice =
                     metadataExtractor.sliceForChunk(nlpResult, start, end);
-
-            // Legacy string-keyed metadata map — Path A populates it at
-            // processOneDirectiveConfig, so Path B must too or downstream
-            // consumers that read from SemanticChunk.metadata silently get
-            // empty data on every sentence chunk. containsUrlPlaceholder=false
-            // because Path B walks raw NLP sentence spans and never runs the
-            // URL substitute/restore pipeline — any URL in sanitizedText is
-            // a real URL, not a placeholder.
-            Map<String, Value> extractedMetadata = metadataExtractor.extractAllMetadata(
-                    sanitizedText, i, sentences.length, false, nlpSlice);
-
-            // §9 dedup groundwork: SHA-256 content_hash of the sanitised
-            // sentence text, stamped into the chunk metadata map. Same
-            // scheme and key name as Path A so downstream dedup logic can
-            // work uniformly across both paths. Identical sentences across
-            // docs → identical hash → dedup candidate.
-            String contentHash = ChunkerSupport.sha256Hex(sanitizedText);
-            extractedMetadata.put("content_hash",
-                    Value.newBuilder().setStringValue(contentHash).build());
 
             // §4.1: chunk_analytics is ALWAYS populated, including on sentences_internal chunks.
             // 8-arg overload uses the pre-computed slice for base text stats
@@ -722,9 +692,9 @@ public class ChunkerGrpcImpl implements PipeStepProcessorService {
                     sanitizedText, i, sentences.length, false,
                     nlpSlice, nlpResult, start, end);
 
-            // PR-K2: promote content_hash to the typed ChunkAnalytics field.
-            // Same pattern as Path A — keeps the loose-map entry for
-            // backward compat and adds the typed field as canonical.
+            // PR-K2 promoted content_hash to the typed ChunkAnalytics field.
+            // PR-K3 removed the duplicate write to the loose metadata map.
+            String contentHash = ChunkerSupport.sha256Hex(sanitizedText);
             chunkAnalytics = chunkAnalytics.toBuilder()
                     .setContentHash(contentHash)
                     .build();
@@ -738,12 +708,13 @@ public class ChunkerGrpcImpl implements PipeStepProcessorService {
                     // vector intentionally NOT set — stage-1 placeholder
                     .build();
 
+            // PR-K3: SemanticChunk.metadata not populated. All fields it
+            // used to hold now live exclusively on chunk_analytics.
             SemanticChunk chunk = SemanticChunk.newBuilder()
                     .setChunkId(chunkId)
                     .setChunkNumber(i)
                     .setEmbeddingInfo(embedding)
                     .setChunkAnalytics(chunkAnalytics)
-                    .putAllMetadata(extractedMetadata)
                     .build();
 
             result.add(chunk);

--- a/src/test/java/ai/pipestream/module/chunker/ChunkerDedupGroundworkTest.java
+++ b/src/test/java/ai/pipestream/module/chunker/ChunkerDedupGroundworkTest.java
@@ -5,6 +5,7 @@ import ai.pipestream.data.module.v1.ProcessDataRequest;
 import ai.pipestream.data.module.v1.ProcessDataResponse;
 import ai.pipestream.data.module.v1.ProcessingOutcome;
 import ai.pipestream.data.module.v1.ServiceMetadata;
+import ai.pipestream.data.v1.ChunkAnalytics;
 import ai.pipestream.data.v1.NamedChunkerConfig;
 import ai.pipestream.data.v1.NamedEmbedderConfig;
 import ai.pipestream.data.v1.PipeDoc;
@@ -27,25 +28,29 @@ import java.util.UUID;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
- * Pins the four PR-E production changes from the post-R1 correctness audit:
+ * Pins the four PR-E production changes from the post-R1 correctness audit,
+ * updated through the PR-K series:
  *
  * <ol>
  *   <li><b>content_hash on every chunk</b> — both paths stamp a SHA-256 hex
- *       of the sanitised chunk text into {@code SemanticChunk.metadata}
- *       under the {@code "content_hash"} key. Enables reprocessing dedup,
- *       content-addressed embedder cache keys, and byte-verification of a
- *       future OpenVINO chunker backend against this implementation.</li>
+ *       of the sanitised chunk text. Originally PR-E added it to the loose
+ *       {@code SemanticChunk.metadata} map; PR-K2 promoted it to the typed
+ *       {@code chunk_analytics.content_hash} field; <b>PR-K3 removed the
+ *       loose-map duplicate</b>. The typed proto field is now the canonical
+ *       and only home. Enables reprocessing dedup, content-addressed
+ *       embedder cache keys, and byte-verification of a future OpenVINO
+ *       chunker backend against this implementation.</li>
  *   <li><b>SourceFieldAnalytics fields 3-7</b> — {@code document_analytics},
  *       {@code total_chunks}, {@code average_chunk_size},
  *       {@code min_chunk_size}, and {@code max_chunk_size} are populated on
  *       every SFA entry instead of just {@code source_field} and
  *       {@code chunk_config_id}.</li>
- *   <li><b>Path B legacy metadata map</b> — {@code sentences_internal} chunks
- *       carry the full string-keyed metadata map (word_count, character_count,
- *       etc.) that Path A chunks already had. Before PR-E, sentence chunks
- *       had only {@code chunk_analytics} (typed proto) and an empty metadata
- *       map, silently giving downstream consumers zero data for sentence
- *       chunks read via the legacy map path.</li>
+ *   <li><b>Path B sentences_internal chunks have populated chunk_analytics</b>
+ *       — every sentence chunk carries a fully-populated
+ *       {@code ChunkAnalytics} typed proto. PR-E originally also populated
+ *       a legacy string-keyed {@code SemanticChunk.metadata} map for these
+ *       chunks; <b>PR-K3 removed the loose-map duplicate</b>. The typed
+ *       proto is the only place to read these fields now.</li>
  *   <li><b>parseNamedChunkerConfig hard-fails</b> — a malformed per-config
  *       Struct (unknown field type) now returns {@code PROCESSING_OUTCOME_FAILURE}
  *       with an "Invalid NamedChunkerConfig" message instead of silently
@@ -93,8 +98,10 @@ class ChunkerDedupGroundworkTest {
                         + "sentences_internal SPR (§21.9 union)")
                 .isNotEmpty();
 
-        // Every chunk in every SPR must have content_hash, and the hash must
-        // be a valid 64-char lowercase hex string.
+        // Every chunk in every SPR must have content_hash on the typed
+        // ChunkAnalytics proto, and the hash must be a valid 64-char
+        // lowercase hex string. PR-K3 removed the loose-map duplicate so
+        // the typed field is the only source of truth now.
         int totalChunksSeen = 0;
         for (SemanticProcessingResult spr : sprs) {
             String pathLabel = ChunkerGrpcImpl.SENTENCES_INTERNAL_CONFIG_ID.equals(spr.getChunkConfigId())
@@ -105,17 +112,22 @@ class ChunkerDedupGroundworkTest {
                 totalChunksSeen++;
                 String chunkCtx = pathLabel + " chunk_id='" + chunk.getChunkId() + "'";
 
-                Value hashVal = chunk.getMetadataMap().get("content_hash");
-                assertThat(hashVal)
-                        .as("%s: metadata must contain 'content_hash' key",
-                                chunkCtx)
-                        .isNotNull();
-
-                String hashStr = hashVal.getStringValue();
+                String hashStr = chunk.getChunkAnalytics().getContentHash();
                 assertThat(hashStr)
-                        .as("%s: content_hash must be a 64-char lowercase hex "
-                                + "SHA-256 digest", chunkCtx)
+                        .as("%s: chunk_analytics.content_hash (typed proto) "
+                                + "must be a 64-char lowercase hex SHA-256",
+                                chunkCtx)
                         .matches("^[0-9a-f]{64}$");
+
+                // PR-K3: loose-map content_hash entry must be GONE. Any
+                // future regression that re-introduces it (e.g. someone
+                // copy-pasting from the streaming impl) lights this up.
+                assertThat(chunk.getMetadataMap())
+                        .as("%s: SemanticChunk.metadata must NOT contain a "
+                                + "loose 'content_hash' key — PR-K3 removed "
+                                + "the duplicate; the typed field is canonical",
+                                chunkCtx)
+                        .doesNotContainKey("content_hash");
             }
         }
 
@@ -245,22 +257,29 @@ class ChunkerDedupGroundworkTest {
     }
 
     // =========================================================================
-    // (3) Path B legacy metadata map populated
+    // (3) Path B sentences_internal chunks have populated typed chunk_analytics
+    //
+    // PR-K3 inverted this test: pre-PR-K3 it asserted that the loose metadata
+    // map was POPULATED on sentence chunks (mirroring Path A's behavior).
+    // PR-K3 removed both Path A's AND Path B's loose-map writes — the typed
+    // ChunkAnalytics proto is now the canonical and only home. This test
+    // now asserts (a) the loose map is EMPTY and (b) the typed proto carries
+    // every field that used to live in the loose map.
     // =========================================================================
 
     @Test
-    void sentencesInternalChunksShouldCarryLegacyMetadataMap() {
+    void sentencesInternalChunksShouldHaveTypedAnalyticsAndEmptyLooseMap() {
         VectorSetDirectives directives = TestDirectiveBuilder.withSingleTokenDirective("body", 500, 50);
 
         PipeDoc inputDoc = PipeDoc.newBuilder()
-                .setDocId("path-b-metadata-test-" + UUID.randomUUID())
+                .setDocId("path-b-typed-analytics-" + UUID.randomUUID())
                 .setSearchMetadata(SearchMetadata.newBuilder()
                         .setBody(BODY_TEXT)
                         .setVectorSetDirectives(directives)
                         .build())
                 .build();
 
-        ProcessDataResponse response = runProcessData(inputDoc, "path-b-metadata");
+        ProcessDataResponse response = runProcessData(inputDoc, "path-b-typed");
 
         SemanticProcessingResult sentencesSpr = response.getOutputDoc()
                 .getSearchMetadata().getSemanticResultsList().stream()
@@ -273,59 +292,57 @@ class ChunkerDedupGroundworkTest {
                 .as("sentences_internal SPR must have at least one chunk")
                 .isNotEmpty();
 
-        // Every sentence chunk must carry the legacy string-keyed metadata
-        // map fields that Path A already populated — word_count, character_count,
-        // sentence_count, is_first_chunk, is_last_chunk, relative_position,
-        // contains_urlplaceholder, etc. Plus content_hash from change (1).
         for (SemanticChunk chunk : sentencesSpr.getChunksList()) {
             String ctx = "sentences_internal chunk_id='" + chunk.getChunkId() + "'";
-            var metadata = chunk.getMetadataMap();
 
-            assertThat(metadata)
-                    .as("%s: metadata map must NOT be empty — Path B must "
-                            + "populate extractAllMetadata just like Path A",
+            // PR-K3: loose metadata map must be EMPTY for chunks emitted by
+            // the chunker. Future caller-injected metadata can land here as
+            // an extension point, but the chunker itself writes nothing.
+            assertThat(chunk.getMetadataMap())
+                    .as("%s: SemanticChunk.metadata must be EMPTY — PR-K3 "
+                            + "removed all loose-map writes from the chunker. "
+                            + "Any non-empty entries are a regression where "
+                            + "someone is re-introducing the duplication.",
                             ctx)
-                    .isNotEmpty();
+                    .isEmpty();
 
-            assertThat(metadata)
-                    .as("%s: metadata map must contain 'word_count'", ctx)
-                    .containsKey("word_count");
+            // The typed ChunkAnalytics proto must carry every field that
+            // used to live in the loose map. Spot-check the most important
+            // ones — the rest are pinned by ChunkerStepInvariantsTest's
+            // post-chunker invariant check.
+            assertThat(chunk.hasChunkAnalytics())
+                    .as("%s: chunk_analytics must be populated (§4.1)", ctx)
+                    .isTrue();
 
-            assertThat(metadata)
-                    .as("%s: metadata map must contain 'character_count'", ctx)
-                    .containsKey("character_count");
+            ChunkAnalytics analytics = chunk.getChunkAnalytics();
 
-            assertThat(metadata)
-                    .as("%s: metadata map must contain 'sentence_count'", ctx)
-                    .containsKey("sentence_count");
+            assertThat(analytics.getWordCount())
+                    .as("%s: chunk_analytics.word_count must be > 0 for a "
+                            + "non-empty sentence", ctx)
+                    .isGreaterThan(0);
 
-            assertThat(metadata)
-                    .as("%s: metadata map must contain 'is_first_chunk'", ctx)
-                    .containsKey("is_first_chunk");
+            assertThat(analytics.getCharacterCount())
+                    .as("%s: chunk_analytics.character_count must be > 0", ctx)
+                    .isGreaterThan(0);
 
-            assertThat(metadata)
-                    .as("%s: metadata map must contain 'is_last_chunk'", ctx)
-                    .containsKey("is_last_chunk");
+            assertThat(analytics.getSentenceCount())
+                    .as("%s: chunk_analytics.sentence_count must be > 0", ctx)
+                    .isGreaterThan(0);
 
-            assertThat(metadata)
-                    .as("%s: metadata map must contain 'relative_position'", ctx)
-                    .containsKey("relative_position");
-
-            assertThat(metadata)
-                    .as("%s: metadata map must contain 'contains_urlplaceholder'", ctx)
-                    .containsKey("contains_urlplaceholder");
-
-            assertThat(metadata.get("contains_urlplaceholder").getBoolValue())
-                    .as("%s: contains_urlplaceholder is always false on Path B "
-                            + "(sentence chunks bypass the URL substitute/restore "
-                            + "pipeline — they walk raw NLP spans)", ctx)
+            // Path B never runs URL substitution, so contains_url_placeholder
+            // must always be false on sentence chunks.
+            assertThat(analytics.getContainsUrlPlaceholder())
+                    .as("%s: chunk_analytics.contains_url_placeholder must be "
+                            + "false on Path B — sentence chunks bypass the "
+                            + "URL substitute/restore pipeline (they walk raw "
+                            + "NLP spans)", ctx)
                     .isFalse();
 
-            // Sanity-check the word_count is non-zero for non-trivial sentences.
-            double wordCount = metadata.get("word_count").getNumberValue();
-            assertThat(wordCount)
-                    .as("%s: word_count must be > 0 for a non-empty sentence", ctx)
-                    .isGreaterThan(0);
+            // PR-K2 added content_hash to the typed proto.
+            assertThat(analytics.getContentHash())
+                    .as("%s: chunk_analytics.content_hash must be a 64-char "
+                            + "lowercase hex SHA-256", ctx)
+                    .matches("^[0-9a-f]{64}$");
         }
     }
 
@@ -411,6 +428,19 @@ class ChunkerDedupGroundworkTest {
     // =========================================================================
 
     private ProcessDataResponse runProcessData(PipeDoc doc, String streamIdPrefix) {
+        // PR-K3: disable the chunk cache so each test run computes from
+        // scratch. The cache key is (sourceText, chunkerConfigId), and
+        // BODY_TEXT is a constant — without this, an entry written by an
+        // earlier test run (or an earlier branch's code) shadows the
+        // current code path's output. Cache hits would skip the new
+        // metadata-map-empty behavior and surface as confusing failures
+        // that look like the production code is still writing the loose
+        // map when in fact it isn't.
+        Struct cacheDisabledConfig = Struct.newBuilder()
+                .putFields("cache_enabled",
+                        com.google.protobuf.Value.newBuilder().setBoolValue(false).build())
+                .build();
+
         ProcessDataRequest request = ProcessDataRequest.newBuilder()
                 .setDocument(doc)
                 .setMetadata(ServiceMetadata.newBuilder()
@@ -420,7 +450,7 @@ class ChunkerDedupGroundworkTest {
                         .setCurrentHopNumber(1)
                         .build())
                 .setConfig(ProcessConfiguration.newBuilder()
-                        .setJsonConfig(Struct.getDefaultInstance())
+                        .setJsonConfig(cacheDisabledConfig)
                         .build())
                 .build();
 
@@ -434,11 +464,13 @@ class ChunkerDedupGroundworkTest {
     }
 
     private static List<String> extractContentHashes(ProcessDataResponse response) {
+        // PR-K3: read from the typed chunk_analytics.content_hash field.
+        // The loose-map "content_hash" entry was removed from the chunker
+        // output in PR-K3.
         return response.getOutputDoc().getSearchMetadata().getSemanticResultsList().stream()
                 .flatMap(spr -> spr.getChunksList().stream())
-                .map(chunk -> chunk.getMetadataMap().get("content_hash"))
-                .filter(v -> v != null)
-                .map(Value::getStringValue)
+                .map(chunk -> chunk.getChunkAnalytics().getContentHash())
+                .filter(s -> !s.isEmpty())
                 .sorted()
                 .toList();
     }

--- a/src/test/java/ai/pipestream/module/chunker/ChunkerTypedAnalyticsFieldsTest.java
+++ b/src/test/java/ai/pipestream/module/chunker/ChunkerTypedAnalyticsFieldsTest.java
@@ -13,7 +13,6 @@ import ai.pipestream.data.v1.SemanticChunk;
 import ai.pipestream.data.v1.SemanticProcessingResult;
 import ai.pipestream.data.v1.VectorSetDirectives;
 import com.google.protobuf.Struct;
-import com.google.protobuf.Value;
 import io.quarkus.grpc.GrpcClient;
 import io.quarkus.test.junit.QuarkusTest;
 import org.junit.jupiter.api.Test;
@@ -64,7 +63,14 @@ class ChunkerTypedAnalyticsFieldsTest {
             + "in tail latency and a substantial improvement in throughput.";
 
     @Test
-    void typedContentHashShouldBePopulatedAndMatchLooseMap() {
+    void typedContentHashShouldBePopulatedAndLooseMapEntryGone() {
+        // PR-K2 added the typed field; this test originally also asserted
+        // the loose-map "content_hash" entry was still present (additive
+        // landing window). PR-K3 closed that window — this test now
+        // asserts the typed field is populated AND the loose-map entry
+        // is GONE. Any future regression that re-introduces the loose-map
+        // duplicate (e.g. someone copy-pasting from the streaming impl)
+        // lights this up.
         VectorSetDirectives directives = TestDirectiveBuilder.withSingleTokenDirective("body", 500, 50);
 
         PipeDoc inputDoc = PipeDoc.newBuilder()
@@ -97,22 +103,13 @@ class ChunkerTypedAnalyticsFieldsTest {
                                 chunkCtx)
                         .matches("^[0-9a-f]{64}$");
 
-                // Loose-map entry must STILL be present (additive landing) and
-                // byte-equivalent to the typed field. After the consumer audit
-                // a follow-up PR will remove this duplication.
-                Value looseHashVal = chunk.getMetadataMap().get("content_hash");
-                assertThat(looseHashVal)
-                        .as("%s: loose-map content_hash entry must still exist "
-                                + "during the additive landing window", chunkCtx)
-                        .isNotNull();
-
-                assertThat(looseHashVal.getStringValue())
-                        .as("%s: typed and loose-map content_hash must agree "
-                                + "byte-for-byte during the additive window — "
-                                + "any drift means the producer is computing "
-                                + "two different hashes for the same text",
-                                chunkCtx)
-                        .isEqualTo(typedHash);
+                // PR-K3: loose-map "content_hash" entry must be GONE.
+                assertThat(chunk.getMetadataMap())
+                        .as("%s: SemanticChunk.metadata must NOT contain a "
+                                + "loose 'content_hash' key — PR-K3 removed "
+                                + "the duplicate; chunk_analytics.content_hash "
+                                + "is the canonical and only home", chunkCtx)
+                        .doesNotContainKey("content_hash");
             }
         }
 
@@ -275,6 +272,16 @@ class ChunkerTypedAnalyticsFieldsTest {
     }
 
     private ProcessDataResponse runProcessData(PipeDoc doc, String streamIdPrefix) {
+        // PR-K3: disable the chunk cache so each test run computes from
+        // scratch. The cache key is (sourceText, chunkerConfigId), and
+        // POS_RICH_BODY is a constant — without this, an entry written by
+        // an earlier test run (or an earlier branch's code) shadows the
+        // current code path's output.
+        Struct cacheDisabledConfig = Struct.newBuilder()
+                .putFields("cache_enabled",
+                        com.google.protobuf.Value.newBuilder().setBoolValue(false).build())
+                .build();
+
         ProcessDataRequest request = ProcessDataRequest.newBuilder()
                 .setDocument(doc)
                 .setMetadata(ServiceMetadata.newBuilder()
@@ -284,7 +291,7 @@ class ChunkerTypedAnalyticsFieldsTest {
                         .setCurrentHopNumber(1)
                         .build())
                 .setConfig(ProcessConfiguration.newBuilder()
-                        .setJsonConfig(Struct.getDefaultInstance())
+                        .setJsonConfig(cacheDisabledConfig)
                         .build())
                 .build();
 


### PR DESCRIPTION
## Summary

Closes the additive-landing window opened by PR-K2. The 17 fields PR-J's audit identified as duplicated between \`SemanticChunk.metadata\` (loose map) and \`ChunkAnalytics\` (typed proto) PLUS \`content_hash\` now live exclusively on the typed proto. The loose map is **empty per chunk**, preserved as an extension point for future caller-injected metadata.

**Net wire-format size reduction**: every chunker output drops ~250-400 bytes per chunk (depending on text length). On a 1000-court-opinion run with ~400 chunks per opinion, that's ~100-160 MB of duplicated bytes saved per request batch.

## Cross-repo audit confirmed near-zero blast radius

Performed during R2 reconnaissance:

| Consumer | Reads `chunk.metadata`? | Reads `chunk.chunk_analytics`? |
|---|---|---|
| `module-embedder` | ❌ none | ❌ none — only reads `text_content` |
| `module-opensearch-sink` | ❌ none | ✅ typed reads |
| `pipestream-opensearch/opensearch-manager` (Separate, ChunkCombined, Nested indexing strategies) | ❌ none | ✅ typed reads |
| `module-semantic-manager.SemanticIndexingOrchestrator:987` | ⚠ whole-map propagation only | ✅ typed reads |
| All others | n/a — different protos | n/a |

The **only** loose-map reader anywhere in the ecosystem is `SemanticIndexingOrchestrator.SemanticIndexingOrchestrator:987`, which does `chunkBuilder.putAllMetadata(chunk.getMetadataMap())` — whole-map propagation, no key-specific lookups. AND `module-semantic-manager` is the **dead god-module being replaced** by chunker → embedder → semantic-graph. Removing the loose-map writes here means the orchestrator propagates fewer entries from a doomed call chain.

## Production changes

Both **Path A** (`processOneDirectiveConfig`) and **Path B** (`buildSentenceChunks`) in \`ChunkerGrpcImpl\`:

- **Removed**: \`metadataExtractor.extractAllMetadata(...)\` call
- **Removed**: \`extractedMetadata.put(\"content_hash\", ...)\` loose-map write
- **Removed**: \`.putAllMetadata(extractedMetadata)\` on the \`SemanticChunk\` builder
- **Kept**: \`chunkAnalytics.toBuilder().setContentHash(contentHash).build()\` (PR-K2's typed-field promotion is now the only source of truth)

\`extractAllMetadata\` itself stays on \`ChunkMetadataExtractor\` because \`ChunkerStreamingGrpcImpl\` still calls it — backlog item to mirror this cleanup to the streaming impl.

## Test changes

### \`ChunkerDedupGroundworkTest\`

- **\`everyChunkShouldCarrySha256ContentHash\`** — reads \`chunk.getChunkAnalytics().getContentHash()\` instead of the loose map. Plus a NEW assertion that the loose-map \`\"content_hash\"\` key is GONE — any future regression that re-introduces the duplicate (e.g. someone copy-pasting from the streaming impl) lights this up.
- **\`extractContentHashes\`** helper — same migration to the typed field.
- **\`sentencesInternalChunksShouldCarryLegacyMetadataMap\`** → renamed to **\`sentencesInternalChunksShouldHaveTypedAnalyticsAndEmptyLooseMap\`** and **inverted**. Pre-PR-K3 it asserted the loose map WAS populated; now it asserts the loose map is EMPTY and the typed \`chunk_analytics\` carries every field that used to live there.

### \`ChunkerTypedAnalyticsFieldsTest\`

- **\`typedContentHashShouldBePopulatedAndMatchLooseMap\`** → renamed to **\`typedContentHashShouldBePopulatedAndLooseMapEntryGone\`** and inverted. Pre-PR-K3 asserted both the typed field AND the loose-map entry were present (the explicit additive-landing-window assertion); now asserts the typed field is populated AND the loose-map entry is GONE.

### Both tests' \`runProcessData\` helpers — \`cache_enabled=false\`

The chunk cache key is \`(sourceText, chunkerConfigId)\`. Test bodies are constants (\`BODY_TEXT\`, \`POS_RICH_BODY\`), so test runs hit cache entries from EARLIER runs (or earlier branches) that still had the loose-map shape. Disabling the cache in these tests via \`cache_enabled=false\` in the request's \`json_config\` is the cleanest fix — each test computes its chunks fresh from the production code path under test.

The first test run after this PR's production changes initially failed with the loose map FULLY populated (\`alphanumeric_percentage\`, \`word_count\`, \`content_hash\`, all 17 keys present). That looked like the production code wasn't taking effect — but it was actually a Redis cache hit returning chunks written by an earlier branch's code path. The \`cache_enabled=false\` hint proved the hypothesis: the new code path is correct, the cache was just shadowing it.

## Test plan

- [x] \`./gradlew compileJava\` — clean
- [x] \`./gradlew test\` — **282 tests, 0 failures, 0 errors** (no test count change — same number of tests, two of them inverted in semantics)
- [ ] CI green

## Follow-ups

- **Backlog**: mirror this cleanup to \`ChunkerStreamingGrpcImpl\`. The streaming impl still writes \`word_count\`, \`character_count\`, etc. to its own loose metadata map. Same deletion can be applied there with the same near-zero downstream risk. Pairs naturally with the separate backlog item to mirror PR-I's slice optimization to the streaming impl.
- **Eventually**: delete \`extractAllMetadata\` from \`ChunkMetadataExtractor\` entirely (zero callers once the streaming impl migration above lands).