### PR TITLE
perf(chunker): mirror PR-I slice + PR-K3 loose-map cleanup to streaming impl

### DIFF
--- a/src/main/java/ai/pipestream/module/chunker/ChunkerStreamingGrpcImpl.java
+++ b/src/main/java/ai/pipestream/module/chunker/ChunkerStreamingGrpcImpl.java
@@ -28,7 +28,6 @@ import jakarta.inject.Singleton;
 import org.jboss.logging.Logger;
 
 import java.util.List;
-import java.util.Map;
 
 /**
  * Streaming gRPC service for chunking text. Implements the SemanticChunkerService
@@ -125,17 +124,29 @@ public class ChunkerStreamingGrpcImpl implements SemanticChunkerService {
                         boolean isLastChunkInConfig = (i == chunks.size() - 1);
                         boolean isVeryLastChunk = isLastConfig && isLastChunkInConfig;
 
-                        // Extract metadata (legacy map) and typed analytics
-                        Map<String, com.google.protobuf.Value> chunkMetadata = metadataExtractor.extractAllMetadata(
-                                chunk.text(), i, chunks.size(), false);
+                        // PR-I mirror: compute the NLP slice ONCE per chunk so
+                        // extractChunkAnalytics reuses it for POS density +
+                        // base text stats instead of re-running OpenNLP on
+                        // chunk text. sliceForChunk returns null if the
+                        // doc-level NLP is missing or the offsets don't
+                        // line up; the extractor then falls back to per-chunk
+                        // OpenNLP.
+                        ChunkMetadataExtractor.ChunkNlpSlice nlpSlice =
+                                metadataExtractor.sliceForChunk(nlpResult,
+                                        chunk.originalIndexStart(), chunk.originalIndexEnd());
+
                         ChunkAnalytics chunkAnalytics = metadataExtractor.extractChunkAnalytics(
                                 chunk.text(), i, chunks.size(), false,
-                                nlpResult, chunk.originalIndexStart(), chunk.originalIndexEnd());
+                                nlpSlice, nlpResult,
+                                chunk.originalIndexStart(), chunk.originalIndexEnd());
 
-                        // Compute SHA-256 content hash
+                        // PR-K3 mirror: content_hash lives exclusively on the
+                        // typed ChunkAnalytics proto. The loose-map duplicate
+                        // that earlier branches wrote here is gone.
                         String contentHash = ChunkerSupport.sha256Hex(chunk.text());
-                        chunkMetadata.put("content_hash",
-                                com.google.protobuf.Value.newBuilder().setStringValue(contentHash).build());
+                        chunkAnalytics = chunkAnalytics.toBuilder()
+                                .setContentHash(contentHash)
+                                .build();
 
                         StreamChunksResponse.Builder responseBuilder = StreamChunksResponse.newBuilder()
                                 .setRequestId(requestId)
@@ -148,7 +159,6 @@ public class ChunkerStreamingGrpcImpl implements SemanticChunkerService {
                                 .setChunkConfigId(chunkConfigId)
                                 .setSourceFieldName(effectiveSourceField)
                                 .setIsLast(isVeryLastChunk)
-                                .putAllMetadata(chunkMetadata)
                                 .setChunkAnalytics(chunkAnalytics);
 
                         // Populate document analytics on the last chunk of EACH config group
@@ -233,16 +243,19 @@ public class ChunkerStreamingGrpcImpl implements SemanticChunkerService {
                     Chunk chunk = chunks.get(i);
                     boolean isLast = (i == chunks.size() - 1);
 
-                    // Extract metadata (legacy map) and typed analytics
-                    Map<String, com.google.protobuf.Value> chunkMetadata = metadataExtractor.extractAllMetadata(
-                            chunk.text(), i, chunks.size(), false);
+                    // Legacy path doesn't pre-compute NlpResult (no multi-config
+                    // fan-out to amortize it over), so extractChunkAnalytics runs
+                    // OpenNLP per chunk. That's existing behaviour — the PR-K3
+                    // cleanup just drops the loose-map writes.
                     ChunkAnalytics chunkAnalytics = metadataExtractor.extractChunkAnalytics(
                             chunk.text(), i, chunks.size(), false);
 
-                    // Compute SHA-256 content hash of the chunk text
+                    // PR-K3 mirror: content_hash lives exclusively on the typed
+                    // ChunkAnalytics proto. No loose-map duplicate.
                     String contentHash = ChunkerSupport.sha256Hex(chunk.text());
-                    chunkMetadata.put("content_hash",
-                            com.google.protobuf.Value.newBuilder().setStringValue(contentHash).build());
+                    chunkAnalytics = chunkAnalytics.toBuilder()
+                            .setContentHash(contentHash)
+                            .build();
 
                     StreamChunksResponse.Builder responseBuilder = StreamChunksResponse.newBuilder()
                             .setRequestId(requestId)
@@ -255,7 +268,6 @@ public class ChunkerStreamingGrpcImpl implements SemanticChunkerService {
                             .setChunkConfigId(chunkConfigId)
                             .setSourceFieldName(effectiveSourceField)
                             .setIsLast(isLast)
-                            .putAllMetadata(chunkMetadata)
                             .setChunkAnalytics(chunkAnalytics);
 
                     // Populate document analytics and total_chunks on the last chunk only

--- a/src/test/java/ai/pipestream/module/chunker/ChunkerStreamingTest.java
+++ b/src/test/java/ai/pipestream/module/chunker/ChunkerStreamingTest.java
@@ -348,24 +348,32 @@ class ChunkerStreamingTest {
     }
 
     @Test
-    void testStreamChunks_metadataMapStillPopulated() {
+    void testStreamChunks_metadataMapIsEmpty_typedAnalyticsCarriesData() {
+        // PR-K3 streaming mirror: the loose metadata map must be empty on
+        // streaming responses — every field that used to live in the loose
+        // map (word_count, sentence_count, content_hash, ...) now lives on
+        // the typed ChunkAnalytics proto only. If this regresses it means
+        // someone re-introduced a putAllMetadata / putMetadata call in
+        // ChunkerStreamingGrpcImpl — probably copy-pasted from the pre-K3
+        // code that is now gone.
         String text = loadResource("demo-documents/texts/sample_article.txt");
         List<StreamChunksResponse> chunks = streamChunks("body", text, "metadata_test", null);
 
-        // Legacy metadata map should still be populated alongside typed analytics
         for (StreamChunksResponse chunk : chunks) {
-            assertThat("Legacy metadata map should have word_count",
-                    chunk.getMetadataMap().containsKey("word_count"), is(true));
-            assertThat("Legacy metadata map should have sentence_count",
-                    chunk.getMetadataMap().containsKey("sentence_count"), is(true));
+            assertThat("Loose metadata map must be empty post-PR-K3 (found keys: "
+                            + chunk.getMetadataMap().keySet() + ")",
+                    chunk.getMetadataMap().isEmpty(), is(true));
 
-            // Typed analytics should agree with legacy metadata
-            if (chunk.hasChunkAnalytics()) {
-                int typedWordCount = chunk.getChunkAnalytics().getWordCount();
-                int legacyWordCount = (int) chunk.getMetadataMap().get("word_count").getNumberValue();
-                assertThat("Typed and legacy word_count should agree",
-                        typedWordCount, is(legacyWordCount));
-            }
+            // Typed ChunkAnalytics is now the canonical home for all stats.
+            assertThat("Typed ChunkAnalytics must be populated",
+                    chunk.hasChunkAnalytics(), is(true));
+            ChunkAnalytics ca = chunk.getChunkAnalytics();
+            assertThat("Typed word_count > 0", ca.getWordCount(), is(greaterThan(0)));
+            assertThat("Typed sentence_count > 0", ca.getSentenceCount(), is(greaterThan(0)));
+            assertThat("Typed character_count > 0", ca.getCharacterCount(), is(greaterThan(0)));
+            // content_hash promoted from loose map to typed field (PR-K2/K3)
+            assertThat("Typed content_hash is a 64-char lowercase hex SHA-256",
+                    ca.getContentHash().matches("^[0-9a-f]{64}$"), is(true));
         }
     }
 


### PR DESCRIPTION
## Summary

- **PR-I mirror**: `ChunkerStreamingGrpcImpl.streamChunksMultiConfig` now computes `ChunkNlpSlice` once per chunk via `sliceForChunk(...)` and passes it to the 8-arg `extractChunkAnalytics`, eliminating the per-chunk OpenNLP re-runs that PR-I already removed from `ChunkerGrpcImpl`. Drops the `extractAllMetadata` call that was re-running sentence detection + tokenization on every chunk (2 more OpenNLP calls per chunk, 4 total).
- **PR-K3 mirror**: Both streaming paths (multi-config AND legacy) stop writing the 17 duplicated keys into the loose `SemanticChunk.metadata` map — `content_hash` is stamped onto the typed `ChunkAnalytics.content_hash` field (PR-K2) via `toBuilder()` instead of a loose-map put. `.putAllMetadata(chunkMetadata)` is removed from both response builders. The legacy path keeps the 4-arg `extractChunkAnalytics` form because it doesn't pre-compute `NlpResult` — only the loose-map writes change there.
- **Test inversion**: `testStreamChunks_metadataMapStillPopulated` becomes `testStreamChunks_metadataMapIsEmpty_typedAnalyticsCarriesData` — asserts the loose map is empty on every streaming response and the typed `ChunkAnalytics` carries the data (word_count > 0, sentence_count > 0, character_count > 0, content_hash matching `^[0-9a-f]{64}$`). Mirrors the same inversion PR-K3 applied to `ChunkerDedupGroundworkTest`.

## Why

Before PR-I and PR-K3 landed, both gRPC entrypoints (`ChunkerGrpcImpl` = unary, `ChunkerStreamingGrpcImpl` = streaming) had symmetric output shape and perf characteristics. After those two PRs the unary path got ~2× faster (measured: unary mean 96ms→45ms, p50 70ms→26ms on 100 opinions) but the streaming path was still running OpenNLP 4× per chunk AND emitting the old loose-map duplicates. This PR restores symmetry:

- **Perf**: streaming multi-config path now runs OpenNLP **once per document** instead of **4× per chunk per config**. On a 200-chunk 3-config input that's 2400 OpenNLP calls → 1.
- **Wire shape**: consumers of `SemanticChunk.metadata` that reach through gRPC streaming will now see an empty map (same as unary), so the PR-K3 consumer audit's "zero downstream risk" conclusion actually holds for BOTH transports. Without this fix the streaming path would have silently kept shipping the duplicates.

## Test plan

- [x] `./gradlew test` — **282/282 tests pass** (full chunker suite including `ChunkerStreamingTest`, `MultiConfigChunkingTest`, `ChunkerStepInvariantsTest`, `ChunkerDedupGroundworkTest`, `ChunkerTypedAnalyticsFieldsTest`, `ChunkerEmbedderIntegrationTest`)
- [x] Confirmed streaming test (`testStreamChunks_metadataMapIsEmpty_typedAnalyticsCarriesData`) inversion catches any re-introduction of `putAllMetadata` in either streaming path
- [x] Typed `content_hash` asserted as 64-char lowercase hex SHA-256 on every streamed chunk
- [ ] **Manual perf check** (post-merge, optional): re-run the opinion corpus through both paths and confirm streaming-vs-unary gap closes