### PR TITLE
fix(chunker): point dev mode at compose Redis instead of DevServices testcontainer

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -86,3 +86,14 @@ quarkus.log.category."io.quarkus.grpc".level=WARN
 
 # Kafka Dev Services - enabled, will use compose services when available
 %dev.quarkus.kafka.devservices.enabled=true
+
+# Redis: in dev mode, use the shared compose stack's Redis on localhost:6379
+# instead of letting Quarkus DevServices spin up its own testcontainer. The
+# auto-spawned testcontainer asks Docker to attach to network
+# 'pipeline-shared-devservices_default' (the conventional compose-project
+# default network), but the shared compose file declares a NAMED network
+# 'pipeline-test-network' instead, so '_default' doesn't exist → 404 →
+# Quarkus refuses to start. Pointing at the running Redis sidesteps the
+# whole network-attachment dance. Override per-environment via
+# QUARKUS_REDIS_HOSTS env var.
+%dev.quarkus.redis.hosts=redis://localhost:6379


### PR DESCRIPTION
## Summary

- One-line fix: `%dev.quarkus.redis.hosts=redis://localhost:6379` so chunker dev mode uses the shared compose Redis instead of letting Quarkus DevServices spin up its own testcontainer.
- Sidesteps the bricked `./gradlew quarkusDev` symptom: testcontainer asks Docker to attach to network \`pipeline-shared-devservices_default\` (the conventional compose-project default), but the shared compose file declares a NAMED network \`pipeline-test-network\` so \`_default\` doesn't exist → 404 → Quarkus refuses to boot.

## Why this happens

The shared compose stack at \`~/.pipeline/compose-devservices.yml\` runs Redis as \`pipeline-redis\` exposed on host port 6379. The chunker's \`ChunkCacheService\` uses \`ReactiveRedisDataSource\`; with no \`quarkus.redis.hosts\` set, Quarkus DevServices triggers a Redis testcontainer that tries to share the compose project's network. The mismatch between the conventional \`<project>_default\` and the actual \`<project>_pipeline-test-network\` is the root cause.

Pointing at the existing compose Redis avoids the testcontainer entirely.

## Scope

- Only \`%dev.\` is touched. \`%test.\` (unit tests) and the production profile are untouched.
- Same fix needed in \`module-embedder\` and \`repository-service\` (both use \`ReactiveRedisDataSource\`); will land separately.

## Test plan

- [ ] \`./gradlew :module-chunker:quarkusDev\` boots cleanly against the running compose stack
- [ ] \`./gradlew :module-chunker:test\` still green (unit tests don't touch Redis at runtime — Mockito stubs)
- [ ] Override path works: \`QUARKUS_REDIS_HOSTS=redis://otherhost:6379 ./gradlew :module-chunker:quarkusDev\`