### PR TITLE
fix: add %dev http.port override (19002 -> 19102)

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -97,3 +97,5 @@ quarkus.log.category."io.quarkus.grpc".level=WARN
 # whole network-attachment dance. Override per-environment via
 # QUARKUS_REDIS_HOSTS env var.
 %dev.quarkus.redis.hosts=redis://localhost:6379
+
+%dev.quarkus.http.port=19102


### PR DESCRIPTION
Adds a `%dev` profile override so dev mode listens on 19102 while the base port (19002) stays reserved for non-dev profiles. Aligns with the project-wide connector / sink / processing-module convention of base+100 in dev.